### PR TITLE
Fixes issue of missing version number from lookup

### DIFF
--- a/clis/data_clis_check.go
+++ b/clis/data_clis_check.go
@@ -743,7 +743,7 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/latest", org, repo)
 
-	resp, err := http.Get(url)
+	resp, err := http.Head(url)
 	if err != nil {
 		return nil, err
 	}
@@ -754,6 +754,11 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 	}()
 
 	latestUrl, err := resp.Location()
+	if err != nil {
+		return nil, err
+	} else if latestUrl == nil {
+		return nil, fmt.Errorf("unable to retrieve location header from url: %s", url)
+	}
 
 	latestTagMatch := regexp.MustCompile(".*/tag/(.+)").FindStringSubmatch(latestUrl.String())
 	if len(latestTagMatch) < 2 {

--- a/clis/data_clis_check.go
+++ b/clis/data_clis_check.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -760,15 +759,9 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 		}
 	}()
 
-	latestUrl := resp.Header.Get("location")
+	latestUrl := resp.Header.Get("Location")
 	if len(latestUrl) == 0 {
-		latestUrl = resp.Header.Get("Location")
-	}
-	if len(latestUrl) == 0 {
-		headerJson, _ := json.Marshal(resp.Header)
-		buf := new(strings.Builder)
-		_, err = io.Copy(buf, resp.Body)
-		return nil, fmt.Errorf("unable to retrieve location header from url: %s, %s, %s", url, headerJson, buf.String())
+		return nil, fmt.Errorf("unable to retrieve location header from url: %s", url)
 	}
 
 	latestTagMatch := regexp.MustCompile(".*/tag/(.+)").FindStringSubmatch(latestUrl)

--- a/clis/data_clis_check.go
+++ b/clis/data_clis_check.go
@@ -744,7 +744,13 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/latest", org, repo)
 
-	resp, err := http.Head(url)
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/clis/data_clis_check.go
+++ b/clis/data_clis_check.go
@@ -744,7 +744,7 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/latest", org, repo)
 
-	resp, err := http.Get(url)
+	resp, err := http.Head(url)
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +760,9 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 	}
 	if len(latestUrl) == 0 {
 		headerJson, _ := json.Marshal(resp.Header)
-		return nil, fmt.Errorf("unable to retrieve location header from url: %s, %s", url, headerJson)
+		buf := new(strings.Builder)
+		_, err = io.Copy(buf, resp.Body)
+		return nil, fmt.Errorf("unable to retrieve location header from url: %s, %s, %s", url, headerJson, buf.String())
 	}
 
 	latestTagMatch := regexp.MustCompile(".*/tag/(.+)").FindStringSubmatch(latestUrl)

--- a/clis/data_clis_check.go
+++ b/clis/data_clis_check.go
@@ -743,7 +743,7 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/latest", org, repo)
 
-	resp, err := http.Head(url)
+	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/clis/data_clis_check.go
+++ b/clis/data_clis_check.go
@@ -755,7 +755,7 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 
 	latestUrl, err := resp.Location()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s, %s", err.Error(), url)
 	} else if latestUrl == nil {
 		return nil, fmt.Errorf("unable to retrieve location header from url: %s", url)
 	}

--- a/clis/data_clis_check.go
+++ b/clis/data_clis_check.go
@@ -753,12 +753,9 @@ func getLatestGitHubRelease(org string, repo string) (*GitHubRelease, error) {
 		}
 	}()
 
-	latestUrl := resp.Header.Get("location")
-	if len(latestUrl) == 0 {
-		return nil, fmt.Errorf("unable to find latest release location in header response: %s", url)
-	}
+	latestUrl, err := resp.Location()
 
-	latestTagMatch := regexp.MustCompile(".*/tag/(.+)").FindStringSubmatch(latestUrl)
+	latestTagMatch := regexp.MustCompile(".*/tag/(.+)").FindStringSubmatch(latestUrl.String())
 	if len(latestTagMatch) < 2 {
 		return nil, fmt.Errorf("unable to parse latest tag from url: %s", latestUrl)
 	}


### PR DESCRIPTION
- Changes logic for getting latest github release to use redirect header instead of api to prevent rate limiting

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>